### PR TITLE
Update .travis.yml with a node LTS version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-  - 'stable'
-  - '0.12'
-  - '0.10'
+  - lts/dubnium
+  - node
 sudo: false
 cache:
   directories:


### PR DESCRIPTION
New dependency `"git-spawned-stream": "^1.0.1"` requires a node vesion >= 6